### PR TITLE
Use builder pattern to avoid constructor magic.

### DIFF
--- a/src/main/java/nl/knaw/huc/rananostra/FrogSocketClient.java
+++ b/src/main/java/nl/knaw/huc/rananostra/FrogSocketClient.java
@@ -252,7 +252,7 @@ public class FrogSocketClient {
     }
 
     private List<Node> splitText(Text node) {
-      CharSequence text = new StringSlice(node.getValue());
+      CharSequence text = StringSlice.of(node.getValue());
 
       List<Node> newnodes = new ArrayList<>();
       while (true) {

--- a/src/main/java/nl/knaw/huc/rananostra/StringSlice.java
+++ b/src/main/java/nl/knaw/huc/rananostra/StringSlice.java
@@ -11,20 +11,19 @@ final class StringSlice implements CharSequence {
   private final int offset;
   private final int len;
 
-  public StringSlice(String s) {
-    this(s, 0, s.length());
+  public static StringSlice of(String str) {
+    return fromTo(str, 0, str.length());
   }
 
-  public StringSlice(String s, int from, int to) {
-    this(from, to, s);
-    check(from, to, s);
+  public static StringSlice fromTo(String str, int from, int to) {
+    check(from, to, str);
+    return new StringSlice(str, from, to - from);
   }
 
-  // No-check constructor. Arguments swapped to change the signature.
-  private StringSlice(int from, int to, String str) {
+  private StringSlice(String str, int offset, int len) {
     this.str = str;
-    offset = from;
-    len = to - from;
+    this.offset = offset;
+    this.len = len;
   }
 
   @Override
@@ -46,7 +45,7 @@ final class StringSlice implements CharSequence {
   @Override
   public final CharSequence subSequence(int from, int to) {
     check(from, to, this);
-    return new StringSlice(offset + from, offset + to, str);
+    return new StringSlice(str, from, to - from);
   }
 
   public final String toString() {

--- a/src/test/java/nl/knaw/huc/rananostra/TestStringSlice.java
+++ b/src/test/java/nl/knaw/huc/rananostra/TestStringSlice.java
@@ -16,13 +16,13 @@ class TestStringSlice {
   }
 
   private static String slice(String s, int from, int to) {
-    return new StringSlice(s, from, to).toString();
+    return StringSlice.fromTo(s, from, to).toString();
   }
 
   @Test
   void subSequence() {
     String s = "hello_world";
-    CharSequence sub = new StringSlice(s, 0, 6);
+    CharSequence sub = StringSlice.fromTo(s, 0, 6);
     sub = sub.subSequence(5, 6);
     assertEquals("_", sub.toString());
     sub = sub.subSequence(0, 0);
@@ -32,8 +32,8 @@ class TestStringSlice {
   @Test
   void outOfBounds() {
     assertThrows(IndexOutOfBoundsException.class, () ->
-      new StringSlice("", 1, 1));
+      StringSlice.fromTo("", 1, 1));
     assertThrows(IndexOutOfBoundsException.class, () ->
-      new StringSlice("foobar", 1, 1).subSequence(2, 3));
+      StringSlice.fromTo("foobar", 1, 1).subSequence(2, 3));
   }
 }


### PR DESCRIPTION
As we are using a builder pattern already, we might as well just expose it.
This simplifies the constructor (just set internal final fields), relieves
the need for parameter juggling between builder and internal constructor,
and allows for checking incoming parameters *before* using them to construct
anything.

If this actually makes it into a public library, consider expanding builder
pattern to include both from/to and offset/len pattern? This should be easy.